### PR TITLE
Add name to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name              "apache2"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"


### PR DESCRIPTION
Chef version 12 seems to like the name attribute in metadata.rb

See https://docs.chef.io/config_rb_metadata.html
